### PR TITLE
memory.hppを追加

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,7 +1,7 @@
 #ifndef KMC_KLANG_AST_HPP
 #define KMC_KLANG_AST_HPP
 
-#include <memory>
+#include "memory.hpp"
 
 namespace klang {
 namespace ast {

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -1,0 +1,15 @@
+#ifndef KMC_KLANG_MEMORY_HPP
+#define KMC_KLANG_MEMORY_HPP
+
+#include <memory>
+
+namespace klang {
+
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+}  // namespace klang
+
+#endif  // KMC_KLANG_MEMORY_HPP


### PR DESCRIPTION
`<memory>`に`make_unique()`を追加した`memory.hpp`を`<memory>`の代わりに使う。
