### PR TITLE
ASTを微修正

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -11,6 +11,7 @@ class Identifier;
 class Type;
 class IntegerLiteral;
 class CharacterLiteral;
+class StringLiteral;
 class TranslationUnit;
 class FunctionDefinition;
 class ArgumentList;
@@ -44,6 +45,7 @@ using IdentifierPtr = std::unique_ptr<Identifier>;
 using TypePtr = std::unique_ptr<Type>;
 using IntegerLiteralPtr = std::unique_ptr<IntegerLiteral>;
 using CharacterLiteralPtr = std::unique_ptr<CharacterLiteral>;
+using StringLiteralPtr = std::unique_ptr<StringLiteral>;
 using TranslationUnitPtr = std::unique_ptr<TranslationUnit>;
 using FunctionDefinitionPtr = std::unique_ptr<FunctionDefinition>;
 using ArgumentListPtr = std::unique_ptr<ArgumentList>;
@@ -96,6 +98,11 @@ class IntegerLiteral : public Base {
 class CharacterLiteral : public Base {
  public:
   virtual ~CharacterLiteral() = 0;
+};
+
+class StringLiteral : public Base {
+ public:
+  virtual ~StringLiteral() = 0;
 };
 
 class TranslationUnit : public Base {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -10,7 +10,7 @@ class Base;
 class Identifier;
 class Type;
 class IntegerLiteral;
-class Program;
+class TranslationUnit;
 class FunctionDefinition;
 class ArgumentList;
 class Argument;
@@ -42,7 +42,7 @@ using BasePtr = std::unique_ptr<Base>;
 using IdentifierPtr = std::unique_ptr<Identifier>;
 using TypePtr = std::unique_ptr<Type>;
 using IntegerLiteralPtr = std::unique_ptr<IntegerLiteral>;
-using ProgramPtr = std::unique_ptr<Program>;
+using TranslationUnitPtr = std::unique_ptr<TranslationUnit>;
 using FunctionDefinitionPtr = std::unique_ptr<FunctionDefinition>;
 using ArgumentListPtr = std::unique_ptr<ArgumentList>;
 using ArgumentPtr = std::unique_ptr<Argument>;
@@ -91,9 +91,9 @@ class IntegerLiteral : public Base {
   virtual ~IntegerLiteral() = 0;
 };
 
-class Program : public Base {
+class TranslationUnit : public Base {
  public:
-  virtual ~Program() = 0;
+  virtual ~TranslationUnit() = 0;
 };
 
 class FunctionDefinition : public Base {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -10,6 +10,7 @@ class Base;
 class Identifier;
 class Type;
 class IntegerLiteral;
+class CharacterLiteral;
 class TranslationUnit;
 class FunctionDefinition;
 class ArgumentList;
@@ -42,6 +43,7 @@ using BasePtr = std::unique_ptr<Base>;
 using IdentifierPtr = std::unique_ptr<Identifier>;
 using TypePtr = std::unique_ptr<Type>;
 using IntegerLiteralPtr = std::unique_ptr<IntegerLiteral>;
+using CharacterLiteralPtr = std::unique_ptr<CharacterLiteral>;
 using TranslationUnitPtr = std::unique_ptr<TranslationUnit>;
 using FunctionDefinitionPtr = std::unique_ptr<FunctionDefinition>;
 using ArgumentListPtr = std::unique_ptr<ArgumentList>;
@@ -89,6 +91,11 @@ class Type : public Base {
 class IntegerLiteral : public Base {
  public:
   virtual ~IntegerLiteral() = 0;
+};
+
+class CharacterLiteral : public Base {
+ public:
+  virtual ~CharacterLiteral() = 0;
 };
 
 class TranslationUnit : public Base {

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -274,5 +274,10 @@ CharacterLiteralExpressionData::CharacterLiteralExpressionData(
     : character_literal_(std::move(character_literal))
 {}
 
+StringLiteralExpressionData::StringLiteralExpressionData(
+    StringLiteralPtr string_literal)
+    : string_literal_(std::move(string_literal))
+{}
+
 }  // namespace ast
 }  // namespace klang

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -17,7 +17,8 @@ IntegerLiteralData::IntegerLiteralData(const std::string& integer_literal)
     : integer_literal_(integer_literal)
 {}
 
-ProgramData::ProgramData(std::vector<FunctionDefinitionPtr> functions)
+TranslationUnitData::TranslationUnitData(
+    std::vector<FunctionDefinitionPtr> functions)
     : functions_(std::move(functions)) {
   assert(1 <= functions_.size());
 }

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -21,6 +21,10 @@ CharacterLiteralData::CharacterLiteralData(const std::string& character_literal)
     : character_literal_(character_literal)
 {}
 
+StringLiteralData::StringLiteralData(const std::string& string_literal)
+    : string_literal_(string_literal)
+{}
+
 TranslationUnitData::TranslationUnitData(
     std::vector<FunctionDefinitionPtr> functions)
     : functions_(std::move(functions)) {

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -57,20 +57,13 @@ VariableDefinitionStatementData::VariableDefinitionStatementData(
     : variable_definition_(std::move(variable_definition))
 {}
 
-MutableVariableDefinitionData::MutableVariableDefinitionData(
+VariableDefinitionData::VariableDefinitionData(
     TypePtr type_name,
+    bool is_mutable,
     IdentifierPtr variable_name,
     ExpressionPtr expression)
     : type_name_(std::move(type_name)),
-      variable_name_(std::move(variable_name)),
-      expression_(std::move(expression))
-{}
-
-ImmutableVariableDefinitionData::ImmutableVariableDefinitionData(
-    TypePtr type_name,
-    IdentifierPtr variable_name,
-    ExpressionPtr expression)
-    : type_name_(std::move(type_name)),
+      is_mutable_(is_mutable),
       variable_name_(std::move(variable_name)),
       expression_(std::move(expression))
 {}

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -269,5 +269,10 @@ IntegerLiteralExpressionData::IntegerLiteralExpressionData(
     : integer_literal_(std::move(integer_literal))
 {}
 
+CharacterLiteralExpressionData::CharacterLiteralExpressionData(
+    CharacterLiteralPtr character_literal)
+    : character_literal_(std::move(character_literal))
+{}
+
 }  // namespace ast
 }  // namespace klang

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -17,6 +17,10 @@ IntegerLiteralData::IntegerLiteralData(const std::string& integer_literal)
     : integer_literal_(integer_literal)
 {}
 
+CharacterLiteralData::CharacterLiteralData(const std::string& character_literal)
+    : character_literal_(character_literal)
+{}
+
 TranslationUnitData::TranslationUnitData(
     std::vector<FunctionDefinitionPtr> functions)
     : functions_(std::move(functions)) {

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -396,6 +396,13 @@ class IntegerLiteralExpressionData : public PrimaryExpression {
   IntegerLiteralPtr integer_literal_;
 };
 
+class CharacterLiteralExpressionData : public PrimaryExpression {
+ public:
+  CharacterLiteralExpressionData(CharacterLiteralPtr character_literal);
+ private:
+  CharacterLiteralPtr character_literal_;
+};
+
 }  // namespace ast
 }  // namespace klang
 

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -36,6 +36,13 @@ class CharacterLiteralData : public CharacterLiteral {
   std::string character_literal_;
 };
 
+class StringLiteralData : public StringLiteral {
+ public:
+  StringLiteralData(const std::string& string_literal);
+ private:
+  std::string string_literal_;
+};
+
 class TranslationUnitData : public TranslationUnit {
  public:
   TranslationUnitData(std::vector<FunctionDefinitionPtr> functions);

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -403,6 +403,13 @@ class CharacterLiteralExpressionData : public PrimaryExpression {
   CharacterLiteralPtr character_literal_;
 };
 
+class StringLiteralExpressionData : public PrimaryExpression {
+ public:
+  StringLiteralExpressionData(StringLiteralPtr string_literal);
+ private:
+  StringLiteralPtr string_literal_;
+};
+
 }  // namespace ast
 }  // namespace klang
 

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -85,24 +85,15 @@ class VariableDefinitionStatementData : public VariableDefinitionStatement {
   VariableDefinitionPtr variable_definition_;
 };
 
-class MutableVariableDefinitionData : public VariableDefinition {
+class VariableDefinitionData : public VariableDefinition {
  public:
-  MutableVariableDefinitionData(TypePtr type_name,
-                                IdentifierPtr variable_name,
-                                ExpressionPtr expression);
+  VariableDefinitionData(TypePtr type_name,
+                         bool is_mutable,
+                         IdentifierPtr variable_name,
+                         ExpressionPtr expression);
  private:
   TypePtr type_name_;
-  IdentifierPtr variable_name_;
-  ExpressionPtr expression_;
-};
-
-class ImmutableVariableDefinitionData : public VariableDefinition {
- public:
-  ImmutableVariableDefinitionData(TypePtr type_name,
-                                  IdentifierPtr variable_name,
-                                  ExpressionPtr expression);
- private:
-  TypePtr type_name_;
+  bool is_mutable_;
   IdentifierPtr variable_name_;
   ExpressionPtr expression_;
 };

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -29,9 +29,9 @@ class IntegerLiteralData : public IntegerLiteral {
   std::string integer_literal_;
 };
 
-class ProgramData : public Program {
+class TranslationUnitData : public TranslationUnit {
  public:
-  ProgramData(std::vector<FunctionDefinitionPtr> functions);
+  TranslationUnitData(std::vector<FunctionDefinitionPtr> functions);
  private:
   std::vector<FunctionDefinitionPtr> functions_;
 };

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -29,6 +29,13 @@ class IntegerLiteralData : public IntegerLiteral {
   std::string integer_literal_;
 };
 
+class CharacterLiteralData : public CharacterLiteral {
+ public:
+  CharacterLiteralData(const std::string& character_literal);
+ private:
+  std::string character_literal_;
+};
+
 class TranslationUnitData : public TranslationUnit {
  public:
   TranslationUnitData(std::vector<FunctionDefinitionPtr> functions);


### PR DESCRIPTION
- `Program`を`TranslationUnit`に変更
- `MutableVariableDefinitionData`と`ImmutableVariableDefinitionData`を`VariableDefinitionData`に統合。
  - 代わりに`VariableDefinitionData`に`is_mutable_`メンバを追加。
- `CharacterLiteral`、`CharacterLiteralData`、`StringLiteral`、`StringLiteralData`を追加。
