### PR TITLE
空のソースコードに対するparse。

### DIFF
--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2,12 +2,21 @@
 
 #include "parser.hpp"
 
+TEST(parser, emptySource) {
+  std::stringstream is;
+  auto tokens = klang::tokenize(is);
+  klang::Parser p(tokens);
+  auto ptu = p.parse_translation_unit();
+  ASSERT_TRUE(ptu != nullptr);
+}
+
 TEST(parser, morbid) {
   std::stringstream is;
-  is << "def main() -> (int) {\n"
-     << "  x := (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( x ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));\n"
-     << "  return x;\n"
-     << "}\n";
+  std::string nl("\n");
+  is << "def main() -> (int) {" << nl
+     << "  x := (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( x ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));" << nl
+     << "  return x;" << nl
+     << "}" << nl;
   auto tokens = klang::tokenize(is);
   klang::Parser p(tokens);
   EXPECT_TRUE(p.parse_translation_unit() != nullptr);


### PR DESCRIPTION
klang::Parser::parse_translation_unit() の中で、関数定義の数が0 より大きいかのAssertion があるので、そこでAssertion Failure になる。
