### PR TITLE
raw文字列の利用

### DIFF
--- a/test/test_lexer.cpp
+++ b/test/test_lexer.cpp
@@ -11,17 +11,18 @@ TEST(lexer, emptySource) {
 
 TEST(lexer, hello) {
   std::stringstream is;
-  std::string nl("\n");
-  is << "{~" << nl
-     << "  とりあえずのデバッグ用" << nl
-     << "  まだdeclareもstringもない" << nl
-     << "  declare print(string) -> ();" << nl
-     << "~}" << nl
-     << "" << nl
-     << "def main() -> (int) {" << nl
-     << "  print(\"Hello, World!\\n\");" << nl
-     << "  return 0;" << nl
-     << "}" << nl;
+  is <<
+R"({~
+  とりあえずのデバッグ用
+  まだdeclareもstringもない
+  declare print(string) -> ();
+~}
+
+def main() -> (int) {
+  print("Hello, World!\n");
+  return 0;
+}
+)";
   auto tokens = klang::tokenize(is);
   using T = klang::Token;
   using klang::TokenType;


### PR DESCRIPTION
[このあたり](https://github.com/kmc-jp/Klang/blob/master/test/test_lexer.cpp#L15)のコードは[raw文字列](http://ezoeryou.github.io/cpp-book/C++11-Syntax-and-Feature.xhtml#raw.string.literal)を使って書きなおしたほうがいいと思います。
ということで誰かおねがいします。
