### PR TITLE
構文解析器を実装

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ AM_CXXFLAGS = -O2 -std=c++11 -Wall -Wextra
 bin_PROGRAMS = klang
 klang_SOURCES = main.cpp
 
-noinst_LIBRARIES = liblexer.a libastdata.a
+noinst_LIBRARIES = liblexer.a libastdata.a libparser.a
 liblexer_a_SOURCES = lexer.cpp lexer.hpp
 libastdata_a_SOURCES = memory.hpp ast.hpp ast.cpp ast_data.cpp ast_data.hpp
+libparser_a_SOURCES = memory.hpp ast.hpp ast.cpp ast_data.hpp ast_data.cpp parser.hpp parser.cpp

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,4 +1,10 @@
 #include "parser.hpp"
 
 namespace klang {
+
+Parser::Parser(TokenVector tokens)
+    : tokens_(std::move(tokens)),
+      current_(std::begin(tokens_))
+{}
+
 }  // namespace klang

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -36,4 +36,8 @@ bool Parser::advance(int count) {
   return true;
 }
 
+auto Parser::snapshot() const -> Pointer {
+  return current_;
+}
+
 }  // namespace klang

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -488,6 +488,24 @@ ast::MultiplicativeExpressionPtr Parser::parse_multiplicative_expression() {
   return nullptr;
 }
 
+ast::UnaryExpressionPtr Parser::parse_unary_expression() {
+  const auto s = snapshot();
+  if (parse_symbol("not")) {
+    if (auto unary_expression = parse_unary_expression()) {
+      return make_unique<ast::NotExpressionData>(std::move(unary_expression));
+    }
+    rewind(s);
+  } else if (parse_symbol("~")) {
+    if (auto unary_expression = parse_unary_expression()) {
+      return make_unique<ast::MinusExpressionData>(std::move(unary_expression));
+    }
+    rewind(s);
+  } else if (auto postfix_expression = parse_postfix_expression()) {
+    return std::move(postfix_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -168,6 +168,24 @@ ast::CompoundStatementPtr Parser::parse_compound_statement() {
   return nullptr;
 }
 
+ast::IfStatementPtr Parser::parse_if_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("if") && parse_symbol("(")) {
+    if (auto condition = parse_expression()) {
+      if (parse_symbol(")")) {
+        if (auto compound_statement = parse_compound_statement()) {
+          return make_unique<ast::IfStatementData>(
+              std::move(condition),
+              std::move(compound_statement),
+              parse_else_statement());
+        }
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -506,6 +506,15 @@ ast::UnaryExpressionPtr Parser::parse_unary_expression() {
   return nullptr;
 }
 
+ast::PostfixExpressionPtr Parser::parse_postfix_expression() {
+  if (auto postfix_expression = parse_function_call_expression()) {
+    return std::move(postfix_expression);
+  } else if (auto primary_expression = parse_primary_expression()) {
+    return std::move(primary_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -461,6 +461,33 @@ ast::AdditiveExpressionPtr Parser::parse_additive_expression() {
   return nullptr;
 }
 
+ast::MultiplicativeExpressionPtr Parser::parse_multiplicative_expression() {
+  if (auto lhs_expression = parse_unary_expression()) {
+    const auto s = snapshot();
+    if (parse_symbol("*")) {
+      if (auto rhs_expression = parse_multiplicative_expression()) {
+        return make_unique<ast::MultiplyExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol("/")) {
+      if (auto rhs_expression = parse_multiplicative_expression()) {
+        return make_unique<ast::DivideExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol("%")) {
+      if (auto rhs_expression = parse_multiplicative_expression()) {
+        return make_unique<ast::ModuloExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    }
+    return std::move(lhs_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -40,4 +40,8 @@ auto Parser::snapshot() const -> Pointer {
   return current_;
 }
 
+void Parser::rewind(Pointer p) {
+  current_ = p;
+}
+
 }  // namespace klang

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -7,6 +7,10 @@ Parser::Parser(TokenVector tokens)
       current_(std::begin(tokens_))
 {}
 
+TokenType Parser::current_type() const {
+  return is_eof() ? TokenType::IGNORE : current_->type();
+}
+
 bool Parser::is_eof() const {
   using std::end;
   return current_ == end(tokens_);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -550,6 +550,13 @@ ast::ParameterListPtr Parser::parse_parameter_list() {
   return make_unique<ast::ParameterListData>(std::move(parameters));
 }
 
+ast::ParameterPtr Parser::parse_parameter() {
+  if (auto expression = parse_expression()) {
+    return make_unique<ast::ParameterData>(std::move(expression));
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -284,6 +284,28 @@ Parser::parse_variable_definition_statement() {
   return nullptr;
 }
 
+ast::VariableDefinitionPtr Parser::parse_variable_definition() {
+  const auto s = snapshot();
+  if (parse_symbol("def")) {
+    if (auto type_name = parse_type()) {
+      const bool is_mutable = parse_symbol("var");
+      if (auto variable_name = parse_identifier()) {
+        if (parse_symbol(":=")) {
+          if (auto expression = parse_expression()) {
+            return make_unique<ast::VariableDefinitionData>(
+                std::move(type_name),
+                is_mutable,
+                std::move(variable_name),
+                std::move(expression));
+          }
+        }
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -271,6 +271,19 @@ ast::ContinueStatementPtr Parser::parse_continue_statement() {
   return nullptr;
 }
 
+ast::VariableDefinitionStatementPtr
+Parser::parse_variable_definition_statement() {
+  const auto s = snapshot();
+  if (auto variable_definition = parse_variable_definition()) {
+    if (parse_symbol(";")) {
+      return make_unique<ast::VariableDefinitionStatementData>(
+          std::move(variable_definition));
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -395,6 +395,51 @@ ast::AndExpressionPtr Parser::parse_and_expression() {
   return nullptr;
 }
 
+ast::ComparativeExpressionPtr Parser::parse_comparative_expression() {
+  if (auto lhs_expression = parse_additive_expression()) {
+    const auto s = snapshot();
+    if (parse_symbol("=")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::EqualExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol("=/")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::NotEqualExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol("<")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::LessExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol(">")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::GreaterExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol("<=")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::LessOrEqualExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol(">=")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::GreaterOrEqualExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    }
+    return std::move(lhs_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,5 +1,7 @@
 #include "parser.hpp"
 
+#include "ast_data.hpp"
+
 namespace klang {
 
 Parser::Parser(TokenVector tokens)
@@ -14,6 +16,15 @@ bool Parser::parse_symbol(const char* str) {
     return true;
   } else {
     return false;
+  }
+}
+
+ast::IdentifierPtr Parser::parse_identifier() {
+  if (current_type() == TokenType::IDENTIFIER) {
+    advance(1);
+    return make_unique<ast::IdentifierData>(current_string());
+  } else {
+    return nullptr;
   }
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -316,6 +316,10 @@ ast::ExpressionStatementPtr Parser::parse_expression_statement() {
   return nullptr;
 }
 
+ast::ExpressionPtr Parser::parse_expression() {
+  return parse_assign_expression();
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -72,6 +72,33 @@ ast::TranslationUnitPtr Parser::parse_translation_unit() {
   return make_unique<ast::TranslationUnitData>(std::move(functions));
 }
 
+ast::FunctionDefinitionPtr Parser::parse_function_definition() {
+  const auto s = snapshot();
+  if (parse_symbol("def")) {
+    if (auto function_name = parse_identifier()) {
+      if (parse_symbol("(")) {
+        if (auto arguments = parse_argument_list()) {
+          if (parse_symbol(")") && parse_symbol("->") && parse_symbol("(")) {
+            if (auto return_type = parse_type()) {
+              if (parse_symbol(")")) {
+                if (auto function_body = parse_compound_statement()) {
+                  return make_unique<ast::FunctionDefinitionData>(
+                      std::move(function_name),
+                      std::move(arguments),
+                      std::move(return_type),
+                      std::move(function_body));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -515,6 +515,22 @@ ast::PostfixExpressionPtr Parser::parse_postfix_expression() {
   return nullptr;
 }
 
+ast::PostfixExpressionPtr Parser::parse_function_call_expression() {
+  const auto s = snapshot();
+  if (auto function_name = parse_identifier()) {
+    if (parse_symbol("(")) {
+      if (auto parameter_list = parse_parameter_list()) {
+        if (parse_symbol(")")) {
+          return make_unique<ast::FunctionCallData>(
+              std::move(function_name), std::move(parameter_list));
+        }
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -380,6 +380,21 @@ ast::OrExpressionPtr Parser::parse_or_expression() {
   return nullptr;
 }
 
+ast::AndExpressionPtr Parser::parse_and_expression() {
+  if (auto lhs_expression = parse_comparative_expression()) {
+    const auto s = snapshot();
+    if (parse_symbol("and")) {
+      if (auto rhs_expression = parse_and_expression()) {
+        return make_unique<ast::AndExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+    }
+    rewind(s);
+    return std::move(lhs_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -320,6 +320,51 @@ ast::ExpressionPtr Parser::parse_expression() {
   return parse_assign_expression();
 }
 
+ast::AssignExpressionPtr Parser::parse_assign_expression() {
+  if (auto lhs_expression = parse_or_expression()) {
+    const auto s = snapshot();
+    if (parse_symbol(":=")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::AssignExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if(parse_symbol(":+=")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::AddAssignExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if(parse_symbol(":-=")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::SubtractAssignExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if(parse_symbol(":*=")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::MultiplyAssignExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if(parse_symbol(":/=")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::DivideAssignExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if(parse_symbol(":%=")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::ModuloAssignExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    }
+    return std::move(lhs_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -12,4 +12,28 @@ bool Parser::is_eof() const {
   return current_ == end(tokens_);
 }
 
+bool Parser::advance(int count) {
+  using std::begin;
+  using std::end;
+  const auto b = begin(tokens_);
+  const auto e = end(tokens_);
+  while (count < 0) {
+    if (current_ != b) {
+      ++count;
+      --current_;
+    } else {
+      return false;
+    }
+  }
+  while (0 < count) {
+    if (current_ != e) {
+      --count;
+      ++current_;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace klang

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -64,6 +64,14 @@ ast::StringLiteralPtr Parser::parse_string_literal() {
   }
 }
 
+ast::TranslationUnitPtr Parser::parse_translation_unit() {
+  std::vector<ast::FunctionDefinitionPtr> functions;
+  while (auto function = parse_function_definition()) {
+    functions.push_back(std::move(function));
+  }
+  return make_unique<ast::TranslationUnitData>(std::move(functions));
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -440,6 +440,27 @@ ast::ComparativeExpressionPtr Parser::parse_comparative_expression() {
   return nullptr;
 }
 
+ast::AdditiveExpressionPtr Parser::parse_additive_expression() {
+  if (auto lhs_expression = parse_multiplicative_expression()) {
+    const auto s = snapshot();
+    if (parse_symbol("+")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::AddExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    } else if (parse_symbol("-")) {
+      if (auto rhs_expression = parse_additive_expression()) {
+        return make_unique<ast::SubtractExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+      rewind(s);
+    }
+    return std::move(lhs_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -37,6 +37,15 @@ ast::TypePtr Parser::parse_type() {
   }
 }
 
+ast::IntegerLiteralPtr Parser::parse_integer_literal() {
+  if (current_type() == TokenType::NUMBER) {
+    advance(1);
+    return make_unique<ast::IntegerLiteralData>(current_string());
+  } else {
+    return nullptr;
+  }
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,6 +11,11 @@ TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }
 
+std::string Parser::current_string() const {
+  static const std::string empty_string{""};
+  return is_eof() ? empty_string : current_->str();
+}
+
 bool Parser::is_eof() const {
   using std::end;
   return current_ == end(tokens_);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -262,6 +262,15 @@ ast::BreakStatementPtr Parser::parse_break_statement() {
   return nullptr;
 }
 
+ast::ContinueStatementPtr Parser::parse_continue_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("continue") && parse_symbol(";")) {
+    return make_unique<ast::ContinueStatementData>();
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -118,6 +118,18 @@ ast::ArgumentListPtr Parser::parse_argument_list() {
   return make_unique<ast::ArgumentListData>(std::move(arguments));
 }
 
+ast::ArgumentPtr Parser::parse_argument() {
+  const auto s = snapshot();
+  if (auto argument_type = parse_type()) {
+    if (auto argument_name = parse_identifier()) {
+      return make_unique<ast::ArgumentData>(std::move(argument_type),
+                                            std::move(argument_name));
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -7,6 +7,16 @@ Parser::Parser(TokenVector tokens)
       current_(std::begin(tokens_))
 {}
 
+bool Parser::parse_symbol(const char* str) {
+  if (current_type() == TokenType::SYMBOL &&
+      current_string() == std::string{str}) {
+    advance(1);
+    return true;
+  } else {
+    return false;
+  }
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -130,6 +130,29 @@ ast::ArgumentPtr Parser::parse_argument() {
   return nullptr;
 }
 
+ast::StatementPtr Parser::parse_statement() {
+  if (auto statement = parse_compound_statement()) {
+    return std::move(statement);
+  } else if (auto statement = parse_if_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_while_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_for_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_return_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_break_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_continue_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_variable_definition_statement()){
+    return std::move(statement);
+  } else if (auto statement = parse_expression_statement()){
+    return std::move(statement);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,0 +1,4 @@
+#include "parser.hpp"
+
+namespace klang {
+}  // namespace klang

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -99,6 +99,25 @@ ast::FunctionDefinitionPtr Parser::parse_function_definition() {
   return nullptr;
 }
 
+ast::ArgumentListPtr Parser::parse_argument_list() {
+  std::vector<ast::ArgumentPtr> arguments;
+  if (auto first_argument = parse_argument()) {
+    arguments.push_back(std::move(first_argument));
+    while (true) {
+      const auto s = snapshot();
+      if (parse_symbol(",")) {
+        if (auto argument = parse_argument()) {
+          arguments.push_back(std::move(argument));
+          continue;
+        }
+      }
+      rewind(s);
+      break;
+    }
+  }
+  return make_unique<ast::ArgumentListData>(std::move(arguments));
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -186,6 +186,19 @@ ast::IfStatementPtr Parser::parse_if_statement() {
   return nullptr;
 }
 
+ast::IfStatementPtr Parser::parse_else_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("else")) {
+    if (auto else_if_statement = parse_if_statement()) {
+      return std::move(else_if_statement);
+    } else if (auto compound_statement = parse_compound_statement()) {
+      return make_unique<ast::ElseStatementData>(std::move(compound_statement));
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -28,6 +28,15 @@ ast::IdentifierPtr Parser::parse_identifier() {
   }
 }
 
+ast::TypePtr Parser::parse_type() {
+  if (current_type() == TokenType::SYMBOL) {
+    advance(1);
+    return make_unique<ast::TypeData>(current_string());
+  } else {
+    return nullptr;
+  }
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -240,6 +240,19 @@ ast::ForStatementPtr Parser::parse_for_statement() {
   return nullptr;
 }
 
+ast::ReturnStatementPtr Parser::parse_return_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("return")) {
+    if (auto return_value = parse_expression()) {
+      if (parse_symbol(";")) {
+        return make_unique<ast::ReturnStatementData>(std::move(return_value));
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -55,6 +55,15 @@ ast::CharacterLiteralPtr Parser::parse_character_literal() {
   }
 }
 
+ast::StringLiteralPtr Parser::parse_string_literal() {
+  if (current_type() == TokenType::STRING) {
+    advance(1);
+    return make_unique<ast::StringLiteralData>(current_string());
+  } else {
+    return nullptr;
+  }
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -306,6 +306,16 @@ ast::VariableDefinitionPtr Parser::parse_variable_definition() {
   return nullptr;
 }
 
+ast::ExpressionStatementPtr Parser::parse_expression_statement() {
+  const auto s = snapshot();
+  auto expression = parse_expression();
+  if (parse_symbol(";")) {
+    return make_unique<ast::ExpressionStatementData>(std::move(expression));
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -365,6 +365,21 @@ ast::AssignExpressionPtr Parser::parse_assign_expression() {
   return nullptr;
 }
 
+ast::OrExpressionPtr Parser::parse_or_expression() {
+  if (auto lhs_expression = parse_and_expression()) {
+    const auto s = snapshot();
+    if (parse_symbol("or")) {
+      if (auto rhs_expression = parse_or_expression()) {
+        return make_unique<ast::OrExpressionData>(
+            std::move(lhs_expression), std::move(rhs_expression));
+      }
+    }
+    rewind(s);
+    return std::move(lhs_expression);
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -557,6 +557,32 @@ ast::ParameterPtr Parser::parse_parameter() {
   return nullptr;
 }
 
+ast::PrimaryExpressionPtr Parser::parse_primary_expression() {
+  const auto s = snapshot();
+  if (parse_symbol("(")) {
+    if (auto expression = parse_expression()) {
+      if (parse_symbol(")")) {
+        return make_unique<ast::ParenthesizedExpressionData>(
+            std::move(expression));
+      }
+    }
+    rewind(s);
+  } else if (auto identifier = parse_identifier()) {
+    return make_unique<ast::IdentifierExpressionData>(
+        std::move(identifier));
+  } else if (auto integer_literal = parse_integer_literal()) {
+    return make_unique<ast::IntegerLiteralExpressionData>(
+        std::move(integer_literal));
+  } else if (auto character_literal = parse_character_literal()) {
+    return make_unique<ast::CharacterLiteralExpressionData>(
+        std::move(character_literal));
+  } else if (auto string_literal = parse_string_literal()) {
+    return make_unique<ast::StringLiteralExpressionData>(
+        std::move(string_literal));
+  }
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -253,6 +253,15 @@ ast::ReturnStatementPtr Parser::parse_return_statement() {
   return nullptr;
 }
 
+ast::BreakStatementPtr Parser::parse_break_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("break") && parse_symbol(";")) {
+    return make_unique<ast::BreakStatementData>();
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -46,6 +46,15 @@ ast::IntegerLiteralPtr Parser::parse_integer_literal() {
   }
 }
 
+ast::CharacterLiteralPtr Parser::parse_character_literal() {
+  if (current_type() == TokenType::CHARACTER) {
+    advance(1);
+    return make_unique<ast::CharacterLiteralData>(current_string());
+  } else {
+    return nullptr;
+  }
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -216,6 +216,30 @@ ast::WhileStatementPtr Parser::parse_while_statement() {
   return nullptr;
 }
 
+ast::ForStatementPtr Parser::parse_for_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("for") && parse_symbol("(")) {
+    auto init_expression = parse_expression();
+    if (parse_symbol(";")) {
+      auto cond_expression = parse_expression();
+      if (parse_symbol(";")) {
+        auto reinit_expression = parse_expression();
+        if (parse_symbol(")")) {
+          if (auto compound_statement = parse_compound_statement()) {
+            return make_unique<ast::ForStatementData>(
+                std::move(init_expression),
+                std::move(cond_expression),
+                std::move(reinit_expression),
+                std::move(compound_statement));
+          }
+        }
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -531,6 +531,25 @@ ast::PostfixExpressionPtr Parser::parse_function_call_expression() {
   return nullptr;
 }
 
+ast::ParameterListPtr Parser::parse_parameter_list() {
+  std::vector<ast::ParameterPtr> parameters;
+  if (auto first_parameter = parse_parameter()) {
+    parameters.push_back(std::move(first_parameter));
+    while (true) {
+      const auto s = snapshot();
+      if (parse_symbol(",")) {
+        if (auto parameter = parse_parameter()) {
+          parameters.push_back(std::move(parameter));
+          continue;
+        }
+      }
+      rewind(s);
+      break;
+    }
+  }
+  return make_unique<ast::ParameterListData>(std::move(parameters));
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -7,4 +7,9 @@ Parser::Parser(TokenVector tokens)
       current_(std::begin(tokens_))
 {}
 
+bool Parser::is_eof() const {
+  using std::end;
+  return current_ == end(tokens_);
+}
+
 }  // namespace klang

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -199,6 +199,23 @@ ast::IfStatementPtr Parser::parse_else_statement() {
   return nullptr;
 }
 
+ast::WhileStatementPtr Parser::parse_while_statement() {
+  const auto s = snapshot();
+  if (parse_symbol("while") && parse_symbol("(")) {
+    if (auto condition = parse_expression()) {
+      if (parse_symbol(")")) {
+        if (auto compound_statement = parse_compound_statement()) {
+          return make_unique<ast::WhileStatementData>(
+              std::move(condition),
+              std::move(compound_statement));
+        }
+      }
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -153,6 +153,21 @@ ast::StatementPtr Parser::parse_statement() {
   return nullptr;
 }
 
+ast::CompoundStatementPtr Parser::parse_compound_statement() {
+  std::vector<ast::StatementPtr> statements;
+  const auto s = snapshot();
+  if (parse_symbol("{")) {
+    while (auto statement = parse_statement()) {
+      statements.push_back(std::move(statement));
+    }
+    if (parse_symbol("}")) {
+      return make_unique<ast::CompoundStatementData>(std::move(statements));
+    }
+  }
+  rewind(s);
+  return nullptr;
+}
+
 TokenType Parser::current_type() const {
   return is_eof() ? TokenType::IGNORE : current_->type();
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -11,6 +11,7 @@ class Parser {
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;
+  std::string current_string() const;
   bool is_eof() const;
   bool advance(int count);
   Pointer snapshot() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -32,6 +32,7 @@ class Parser {
   ast::VariableDefinitionPtr parse_variable_definition();
   ast::ExpressionStatementPtr parse_expression_statement();
   ast::ExpressionPtr parse_expression();
+  ast::AssignExpressionPtr parse_assign_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -13,6 +13,7 @@ class Parser {
   ast::IdentifierPtr parse_identifier();
   ast::TypePtr parse_type();
   ast::IntegerLiteralPtr parse_integer_literal();
+  ast::CharacterLiteralPtr parse_character_literal();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -34,6 +34,7 @@ class Parser {
   ast::ExpressionPtr parse_expression();
   ast::AssignExpressionPtr parse_assign_expression();
   ast::OrExpressionPtr parse_or_expression();
+  ast::AndExpressionPtr parse_and_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -18,6 +18,7 @@ class Parser {
   ast::TranslationUnitPtr parse_translation_unit();
   ast::FunctionDefinitionPtr parse_function_definition();
   ast::ArgumentListPtr parse_argument_list();
+  ast::ArgumentPtr parse_argument();
   ast::CompoundStatementPtr parse_compound_statement();
  private:
   using Pointer = TokenVector::const_iterator;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -12,6 +12,7 @@ class Parser {
   using Pointer = TokenVector::const_iterator;
   bool is_eof() const;
   bool advance(int count);
+  Pointer snapshot() const;
   const TokenVector tokens_;
   Pointer current_;
 };

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -36,6 +36,7 @@ class Parser {
   ast::OrExpressionPtr parse_or_expression();
   ast::AndExpressionPtr parse_and_expression();
   ast::ComparativeExpressionPtr parse_comparative_expression();
+  ast::AdditiveExpressionPtr parse_additive_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -10,6 +10,7 @@ class Parser {
   Parser(TokenVector tokens);
  private:
   using Pointer = TokenVector::const_iterator;
+  bool is_eof() const;
   const TokenVector tokens_;
   Pointer current_;
 };

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -12,6 +12,7 @@ class Parser {
   bool parse_symbol(const char* str);
   ast::IdentifierPtr parse_identifier();
   ast::TypePtr parse_type();
+  ast::IntegerLiteralPtr parse_integer_literal();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -15,6 +15,8 @@ class Parser {
   ast::IntegerLiteralPtr parse_integer_literal();
   ast::CharacterLiteralPtr parse_character_literal();
   ast::StringLiteralPtr parse_string_literal();
+  ast::TranslationUnitPtr parse_translation_unit();
+  ast::FunctionDefinitionPtr parse_function_definition();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -37,6 +37,7 @@ class Parser {
   ast::AndExpressionPtr parse_and_expression();
   ast::ComparativeExpressionPtr parse_comparative_expression();
   ast::AdditiveExpressionPtr parse_additive_expression();
+  ast::MultiplicativeExpressionPtr parse_multiplicative_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -11,6 +11,7 @@ class Parser {
   Parser(TokenVector tokens);
   bool parse_symbol(const char* str);
   ast::IdentifierPtr parse_identifier();
+  ast::TypePtr parse_type();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -13,6 +13,7 @@ class Parser {
   bool is_eof() const;
   bool advance(int count);
   Pointer snapshot() const;
+  void rewind(Pointer p);
   const TokenVector tokens_;
   Pointer current_;
 };

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -39,6 +39,7 @@ class Parser {
   ast::AdditiveExpressionPtr parse_additive_expression();
   ast::MultiplicativeExpressionPtr parse_multiplicative_expression();
   ast::UnaryExpressionPtr parse_unary_expression();
+  ast::PostfixExpressionPtr parse_postfix_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -42,6 +42,7 @@ class Parser {
   ast::PostfixExpressionPtr parse_postfix_expression();
   ast::PostfixExpressionPtr parse_function_call_expression();
   ast::ParameterListPtr parse_parameter_list();
+  ast::ParameterPtr parse_parameter();
   ast::PrimaryExpressionPtr parse_primary_expression();
  private:
   using Pointer = TokenVector::const_iterator;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -35,6 +35,7 @@ class Parser {
   ast::AssignExpressionPtr parse_assign_expression();
   ast::OrExpressionPtr parse_or_expression();
   ast::AndExpressionPtr parse_and_expression();
+  ast::ComparativeExpressionPtr parse_comparative_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -41,6 +41,7 @@ class Parser {
   ast::UnaryExpressionPtr parse_unary_expression();
   ast::PostfixExpressionPtr parse_postfix_expression();
   ast::PostfixExpressionPtr parse_function_call_expression();
+  ast::ParameterListPtr parse_parameter_list();
   ast::PrimaryExpressionPtr parse_primary_expression();
  private:
   using Pointer = TokenVector::const_iterator;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -11,6 +11,7 @@ class Parser {
  private:
   using Pointer = TokenVector::const_iterator;
   bool is_eof() const;
+  bool advance(int count);
   const TokenVector tokens_;
   Pointer current_;
 };

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -19,7 +19,16 @@ class Parser {
   ast::FunctionDefinitionPtr parse_function_definition();
   ast::ArgumentListPtr parse_argument_list();
   ast::ArgumentPtr parse_argument();
+  ast::StatementPtr parse_statement();
   ast::CompoundStatementPtr parse_compound_statement();
+  ast::IfStatementPtr parse_if_statement();
+  ast::WhileStatementPtr parse_while_statement();
+  ast::ForStatementPtr parse_for_statement();
+  ast::ReturnStatementPtr parse_return_statement();
+  ast::BreakStatementPtr parse_break_statement();
+  ast::ContinueStatementPtr parse_continue_statement();
+  ast::VariableDefinitionStatementPtr parse_variable_definition_statement();
+  ast::ExpressionStatementPtr parse_expression_statement();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -40,6 +40,8 @@ class Parser {
   ast::MultiplicativeExpressionPtr parse_multiplicative_expression();
   ast::UnaryExpressionPtr parse_unary_expression();
   ast::PostfixExpressionPtr parse_postfix_expression();
+  ast::PostfixExpressionPtr parse_function_call_expression();
+  ast::PrimaryExpressionPtr parse_primary_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -8,6 +8,7 @@ namespace klang {
 class Parser {
  public:
   Parser(TokenVector tokens);
+  bool parse_symbol(const char* str);
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -38,6 +38,7 @@ class Parser {
   ast::ComparativeExpressionPtr parse_comparative_expression();
   ast::AdditiveExpressionPtr parse_additive_expression();
   ast::MultiplicativeExpressionPtr parse_multiplicative_expression();
+  ast::UnaryExpressionPtr parse_unary_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -29,6 +29,7 @@ class Parser {
   ast::BreakStatementPtr parse_break_statement();
   ast::ContinueStatementPtr parse_continue_statement();
   ast::VariableDefinitionStatementPtr parse_variable_definition_statement();
+  ast::VariableDefinitionPtr parse_variable_definition();
   ast::ExpressionStatementPtr parse_expression_statement();
   ast::ExpressionPtr parse_expression();
  private:

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -33,6 +33,7 @@ class Parser {
   ast::ExpressionStatementPtr parse_expression_statement();
   ast::ExpressionPtr parse_expression();
   ast::AssignExpressionPtr parse_assign_expression();
+  ast::OrExpressionPtr parse_or_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -22,6 +22,7 @@ class Parser {
   ast::StatementPtr parse_statement();
   ast::CompoundStatementPtr parse_compound_statement();
   ast::IfStatementPtr parse_if_statement();
+  ast::IfStatementPtr parse_else_statement();
   ast::WhileStatementPtr parse_while_statement();
   ast::ForStatementPtr parse_for_statement();
   ast::ReturnStatementPtr parse_return_statement();
@@ -29,6 +30,7 @@ class Parser {
   ast::ContinueStatementPtr parse_continue_statement();
   ast::VariableDefinitionStatementPtr parse_variable_definition_statement();
   ast::ExpressionStatementPtr parse_expression_statement();
+  ast::ExpressionPtr parse_expression();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -10,6 +10,7 @@ class Parser {
   Parser(TokenVector tokens);
  private:
   using Pointer = TokenVector::const_iterator;
+  TokenType current_type() const;
   bool is_eof() const;
   bool advance(int count);
   Pointer snapshot() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,0 +1,11 @@
+#ifndef KMC_KLANG_PARSER_HPP
+#define KMC_KLANG_PARSER_HPP
+
+namespace klang {
+
+class Parser {
+};
+
+}  // namespace klang
+
+#endif  // KMC_KLANG_PARSER_HPP

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -14,6 +14,7 @@ class Parser {
   ast::TypePtr parse_type();
   ast::IntegerLiteralPtr parse_integer_literal();
   ast::CharacterLiteralPtr parse_character_literal();
+  ast::StringLiteralPtr parse_string_literal();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,6 +1,7 @@
 #ifndef KMC_KLANG_PARSER_HPP
 #define KMC_KLANG_PARSER_HPP
 
+#include "ast.hpp"
 #include "lexer.hpp"
 
 namespace klang {
@@ -9,6 +10,7 @@ class Parser {
  public:
   Parser(TokenVector tokens);
   bool parse_symbol(const char* str);
+  ast::IdentifierPtr parse_identifier();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -17,6 +17,8 @@ class Parser {
   ast::StringLiteralPtr parse_string_literal();
   ast::TranslationUnitPtr parse_translation_unit();
   ast::FunctionDefinitionPtr parse_function_definition();
+  ast::ArgumentListPtr parse_argument_list();
+  ast::CompoundStatementPtr parse_compound_statement();
  private:
   using Pointer = TokenVector::const_iterator;
   TokenType current_type() const;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,9 +1,17 @@
 #ifndef KMC_KLANG_PARSER_HPP
 #define KMC_KLANG_PARSER_HPP
 
+#include "lexer.hpp"
+
 namespace klang {
 
 class Parser {
+ public:
+  Parser(TokenVector tokens);
+ private:
+  using Pointer = TokenVector::const_iterator;
+  const TokenVector tokens_;
+  Pointer current_;
 };
 
 }  // namespace klang


### PR DESCRIPTION
- これまでの構文解析器の実装を整理して一つにまとめる。
- 以下のブランチをCloseできる程度の情報を持つ
  - [x] [parser](https://github.com/kmc-jp/Klang/tree/parser)
  - [x] [merging-parser](https://github.com/kmc-jp/Klang/tree/merging-parser)
  - [x] [fix-merging-parser](https://github.com/kmc-jp/Klang/tree/fix-merging-parser)
- 以下の指摘に対処する
  - [x] https://github.com/kmc-jp/Klang/pull/32#issuecomment-56031453
- 参照
  - [文法](https://github.com/kmc-jp/Klang-Koan/blob/PEG/hatsusato/grammar.txt)
- このPull Requestの次にやること
  - `parse_*()`メンバ関数はパースに失敗すると、失敗の原因の情報を返すようにする。
    - エラー情報の保持のために`Either`クラス的なのを作る。
  - `try_parse_*()`メンバ関数はパースの可否を真偽値で返し、イテレータを進めない。
