### PR TITLE
namespace ast以下を整理

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -39,15 +39,6 @@ Statement::~Statement()
 CompoundStatement::~CompoundStatement()
 {}
 
-ExpressionStatement::~ExpressionStatement()
-{}
-
-VariableDefinitionStatement::~VariableDefinitionStatement()
-{}
-
-VariableDefinition::~VariableDefinition()
-{}
-
 IfStatement::~IfStatement()
 {}
 
@@ -64,6 +55,15 @@ BreakStatement::~BreakStatement()
 {}
 
 ContinueStatement::~ContinueStatement()
+{}
+
+VariableDefinitionStatement::~VariableDefinitionStatement()
+{}
+
+VariableDefinition::~VariableDefinition()
+{}
+
+ExpressionStatement::~ExpressionStatement()
 {}
 
 Expression::~Expression()

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -4,103 +4,103 @@ namespace klang {
 namespace ast {
 
 Base::~Base()
-{};
+{}
 
 Identifier::~Identifier()
-{};
+{}
 
 Type::~Type()
-{};
+{}
 
 IntegerLiteral::~IntegerLiteral()
-{};
+{}
 
 CharacterLiteral::~CharacterLiteral()
-{};
+{}
 
 StringLiteral::~StringLiteral()
-{};
+{}
 
 TranslationUnit::~TranslationUnit()
-{};
+{}
 
 FunctionDefinition::~FunctionDefinition()
-{};
+{}
 
 ArgumentList::~ArgumentList()
-{};
+{}
 
 Argument::~Argument()
-{};
+{}
 
 Statement::~Statement()
-{};
+{}
 
 CompoundStatement::~CompoundStatement()
-{};
+{}
 
 ExpressionStatement::~ExpressionStatement()
-{};
+{}
 
 VariableDefinitionStatement::~VariableDefinitionStatement()
-{};
+{}
 
 VariableDefinition::~VariableDefinition()
-{};
+{}
 
 IfStatement::~IfStatement()
-{};
+{}
 
 WhileStatement::~WhileStatement()
-{};
+{}
 
 ForStatement::~ForStatement()
-{};
+{}
 
 ReturnStatement::~ReturnStatement()
-{};
+{}
 
 BreakStatement::~BreakStatement()
-{};
+{}
 
 ContinueStatement::~ContinueStatement()
-{};
+{}
 
 Expression::~Expression()
-{};
+{}
 
 AssignExpression::~AssignExpression()
-{};
+{}
 
 OrExpression::~OrExpression()
-{};
+{}
 
 AndExpression::~AndExpression()
-{};
+{}
 
 ComparativeExpression::~ComparativeExpression()
-{};
+{}
 
 AdditiveExpression::~AdditiveExpression()
-{};
+{}
 
 MultiplicativeExpression::~MultiplicativeExpression()
-{};
+{}
 
 UnaryExpression::~UnaryExpression()
-{};
+{}
 
 PostfixExpression::~PostfixExpression()
-{};
+{}
 
 ParameterList::~ParameterList()
-{};
+{}
 
 Parameter::~Parameter()
-{};
+{}
 
 PrimaryExpression::~PrimaryExpression()
-{};
+{}
 
 }  // namespace ast
 }  // namespace klang

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -18,15 +18,15 @@ class ArgumentList;
 class Argument;
 class Statement;
 class CompoundStatement;
-class ExpressionStatement;
-class VariableDefinitionStatement;
-class VariableDefinition;
 class IfStatement;
 class WhileStatement;
 class ForStatement;
 class ReturnStatement;
 class BreakStatement;
 class ContinueStatement;
+class VariableDefinitionStatement;
+class VariableDefinition;
+class ExpressionStatement;
 class Expression;
 class AssignExpression;
 class OrExpression;
@@ -52,16 +52,16 @@ using ArgumentListPtr = std::unique_ptr<ArgumentList>;
 using ArgumentPtr = std::unique_ptr<Argument>;
 using StatementPtr = std::unique_ptr<Statement>;
 using CompoundStatementPtr = std::unique_ptr<CompoundStatement>;
-using ExpressionStatementPtr = std::unique_ptr<ExpressionStatement>;
-using VariableDefinitionStatementPtr =
-    std::unique_ptr<VariableDefinitionStatement>;
-using VariableDefinitionPtr = std::unique_ptr<VariableDefinition>;
 using IfStatementPtr = std::unique_ptr<IfStatement>;
 using WhileStatementPtr = std::unique_ptr<WhileStatement>;
 using ForStatementPtr = std::unique_ptr<ForStatement>;
 using ReturnStatementPtr = std::unique_ptr<ReturnStatement>;
 using BreakStatementPtr = std::unique_ptr<BreakStatement>;
 using ContinueStatementPtr = std::unique_ptr<ContinueStatement>;
+using VariableDefinitionStatementPtr =
+    std::unique_ptr<VariableDefinitionStatement>;
+using VariableDefinitionPtr = std::unique_ptr<VariableDefinition>;
+using ExpressionStatementPtr = std::unique_ptr<ExpressionStatement>;
 using ExpressionPtr = std::unique_ptr<Expression>;
 using AssignExpressionPtr = std::unique_ptr<AssignExpression>;
 using OrExpressionPtr = std::unique_ptr<OrExpression>;
@@ -135,21 +135,6 @@ class CompoundStatement : public Statement {
   virtual ~CompoundStatement() = 0;
 };
 
-class ExpressionStatement : public Statement {
- public:
-  virtual ~ExpressionStatement() = 0;
-};
-
-class VariableDefinitionStatement : public Statement {
- public:
-  virtual ~VariableDefinitionStatement() = 0;
-};
-
-class VariableDefinition : public Base {
- public:
-  virtual ~VariableDefinition() = 0;
-};
-
 class IfStatement : public Statement {
  public:
   virtual ~IfStatement() = 0;
@@ -178,6 +163,21 @@ class BreakStatement : public Statement {
 class ContinueStatement : public Statement {
  public:
   virtual ~ContinueStatement() = 0;
+};
+
+class VariableDefinitionStatement : public Statement {
+ public:
+  virtual ~VariableDefinitionStatement() = 0;
+};
+
+class VariableDefinition : public Base {
+ public:
+  virtual ~VariableDefinition() = 0;
+};
+
+class ExpressionStatement : public Statement {
+ public:
+  virtual ~ExpressionStatement() = 0;
 };
 
 class Expression : public Base {

--- a/src/ast_data.cpp
+++ b/src/ast_data.cpp
@@ -56,26 +56,6 @@ CompoundStatementData::CompoundStatementData(
     : statements_(std::move(statements))
 {}
 
-ExpressionStatementData::ExpressionStatementData(ExpressionPtr expression)
-    : expression_(std::move(expression))
-{}
-
-VariableDefinitionStatementData::VariableDefinitionStatementData(
-    VariableDefinitionPtr variable_definition)
-    : variable_definition_(std::move(variable_definition))
-{}
-
-VariableDefinitionData::VariableDefinitionData(
-    TypePtr type_name,
-    bool is_mutable,
-    IdentifierPtr variable_name,
-    ExpressionPtr expression)
-    : type_name_(std::move(type_name)),
-      is_mutable_(is_mutable),
-      variable_name_(std::move(variable_name)),
-      expression_(std::move(expression))
-{}
-
 IfStatementData::IfStatementData(ExpressionPtr condition,
                                  CompoundStatementPtr compound_statement,
                                  IfStatementPtr else_statement)
@@ -112,6 +92,26 @@ BreakStatementData::BreakStatementData()
 {}
 
 ContinueStatementData::ContinueStatementData()
+{}
+
+VariableDefinitionStatementData::VariableDefinitionStatementData(
+    VariableDefinitionPtr variable_definition)
+    : variable_definition_(std::move(variable_definition))
+{}
+
+VariableDefinitionData::VariableDefinitionData(
+    TypePtr type_name,
+    bool is_mutable,
+    IdentifierPtr variable_name,
+    ExpressionPtr expression)
+    : type_name_(std::move(type_name)),
+      is_mutable_(is_mutable),
+      variable_name_(std::move(variable_name)),
+      expression_(std::move(expression))
+{}
+
+ExpressionStatementData::ExpressionStatementData(ExpressionPtr expression)
+    : expression_(std::move(expression))
 {}
 
 AssignExpressionData::AssignExpressionData(

--- a/src/ast_data.hpp
+++ b/src/ast_data.hpp
@@ -85,33 +85,6 @@ class CompoundStatementData : public CompoundStatement {
   std::vector<StatementPtr> statements_;
 };
 
-class ExpressionStatementData : public ExpressionStatement {
- public:
-  ExpressionStatementData(ExpressionPtr expression);
- private:
-  ExpressionPtr expression_;
-};
-
-class VariableDefinitionStatementData : public VariableDefinitionStatement {
- public:
-  VariableDefinitionStatementData(VariableDefinitionPtr variable_definition);
- private:
-  VariableDefinitionPtr variable_definition_;
-};
-
-class VariableDefinitionData : public VariableDefinition {
- public:
-  VariableDefinitionData(TypePtr type_name,
-                         bool is_mutable,
-                         IdentifierPtr variable_name,
-                         ExpressionPtr expression);
- private:
-  TypePtr type_name_;
-  bool is_mutable_;
-  IdentifierPtr variable_name_;
-  ExpressionPtr expression_;
-};
-
 class IfStatementData : public IfStatement {
  public:
   IfStatementData(ExpressionPtr condition,
@@ -165,6 +138,33 @@ class BreakStatementData : public BreakStatement {
 class ContinueStatementData : public ContinueStatement {
  public:
   ContinueStatementData();
+};
+
+class VariableDefinitionStatementData : public VariableDefinitionStatement {
+ public:
+  VariableDefinitionStatementData(VariableDefinitionPtr variable_definition);
+ private:
+  VariableDefinitionPtr variable_definition_;
+};
+
+class VariableDefinitionData : public VariableDefinition {
+ public:
+  VariableDefinitionData(TypePtr type_name,
+                         bool is_mutable,
+                         IdentifierPtr variable_name,
+                         ExpressionPtr expression);
+ private:
+  TypePtr type_name_;
+  bool is_mutable_;
+  IdentifierPtr variable_name_;
+  ExpressionPtr expression_;
+};
+
+class ExpressionStatementData : public ExpressionStatement {
+ public:
+  ExpressionStatementData(ExpressionPtr expression);
+ private:
+  ExpressionPtr expression_;
 };
 
 class AssignExpressionData : public AssignExpression {


### PR DESCRIPTION
- ast.cppの冗長なセミコロンを除去。
- 以下のクラスの並び替え。
  - `ExpressionStatement(Data)`
  - `VariableDefinitionStatement(Data)`
  - `VariableDefinition(Data)`
