### PR TITLE
空のソースコードに対するparse。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ src/klang
 /test/test_nothing
 /test/test_sample1
 /test/test_lexer
+/test/test_parser

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -8,7 +8,7 @@ libgtest_all_a_SOURCES = $(GTEST_DIR)/gtest-all.cc $(GTEST_DIR)/gtest.h
 
 GTEST_FILES = helper_test_main.cpp $(GTEST_DIR)/gtest.h
 
-TESTS = test_nothing test_sample1 test_lexer
+TESTS = test_nothing test_sample1 test_lexer test_parser
 
 check_PROGRAMS = $(TESTS)
 test_nothing_SOURCES = test_nothing.cpp # not using gtest
@@ -17,3 +17,6 @@ test_sample1_LDADD = libgtest-all.a
 
 test_lexer_SOURCES = test_lexer.cpp $(GTEST_FILES)
 test_lexer_LDADD = $(check_LIBRARIES) ../src/liblexer.a
+
+test_parser_SOURCES = test_parser.cpp $(GTEST_FILES)
+test_parser_LDADD = $(check_LIBRARIES) ../src/libparser.a ../src/liblexer.a

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2,12 +2,21 @@
 
 #include "parser.hpp"
 
+TEST(parser, emptySource) {
+  std::stringstream is;
+  auto tokens = klang::tokenize(is);
+  klang::Parser p(tokens);
+  auto ptu = p.parse_translation_unit();
+  ASSERT_TRUE(ptu != nullptr);
+}
+
 TEST(parser, morbid) {
   std::stringstream is;
-  is << "def main() -> (int) {\n"
-     << "  x := (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( x ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));\n"
-     << "  return x;\n"
-     << "}\n";
+  std::string nl("\n");
+  is << "def main() -> (int) {" << nl
+     << "  x := (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( x ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));" << nl
+     << "  return x;" << nl
+     << "}" << nl;
   auto tokens = klang::tokenize(is);
   klang::Parser p(tokens);
   EXPECT_TRUE(p.parse_translation_unit() != nullptr);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1,0 +1,14 @@
+#include "gtest.h"
+
+#include "parser.hpp"
+
+TEST(parser, morbid) {
+  std::stringstream is;
+  is << "def main() -> (int) {\n"
+     << "  x := (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( x ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));\n"
+     << "  return x;\n"
+     << "}\n";
+  auto tokens = klang::tokenize(is);
+  klang::Parser p(tokens);
+  EXPECT_TRUE(p.parse_translation_unit() != nullptr);
+}


### PR DESCRIPTION
#43 のを持ってきました。

`test_parser: ast_data.cpp:31: klang::ast::TranslationUnitData::TranslationUnitData(std::vector<std::unique_ptr<klang::ast::FunctionDefinition> >): Assertion 1 <= functions_.size()' failed.`
test がコケていますが、これはtest が正しく、`ast_data.cpp` のバグだと思います。
