### PR TITLE
例外によるエラーハンドリングを実装

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -601,6 +601,8 @@ void Parser::rewind(Pointer p) {
 
 
 void Parser::fail() {
+  current_ = begin(tokens_);
+
   std::stringstream ss;
   ss << "unexpected token " << current_string() << " near at " << current_->line();
   throw std::runtime_error(ss.str());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,8 @@
 #include "parser.hpp"
 
 #include "ast_data.hpp"
+#include <stdexcept>
+#include <sstream>
 
 namespace klang {
 
@@ -9,13 +11,19 @@ Parser::Parser(TokenVector tokens)
       current_(std::begin(tokens_))
 {}
 
-bool Parser::parse_symbol(const char* str) {
+bool Parser::try_symbol(const char* str) {
   if (current_type() == TokenType::SYMBOL &&
       current_string() == std::string{str}) {
     advance(1);
     return true;
   } else {
     return false;
+  }
+}
+
+void Parser::parse_symbol(const char* str) {
+  if (!try_symbol(str)) {
+    fail();
   }
 }
 
@@ -29,7 +37,7 @@ ast::IdentifierPtr Parser::parse_identifier() {
 }
 
 ast::TypePtr Parser::parse_type() {
-  if (current_type() == TokenType::SYMBOL) {
+  if (current_type() == TokenType::SYMBOL && current_string() == "int") {
     advance(1);
     return make_unique<ast::TypeData>(current_string());
   } else {
@@ -73,29 +81,27 @@ ast::TranslationUnitPtr Parser::parse_translation_unit() {
 }
 
 ast::FunctionDefinitionPtr Parser::parse_function_definition() {
-  const auto s = snapshot();
-  if (parse_symbol("def")) {
+  if (try_symbol("def")) {
     if (auto function_name = parse_identifier()) {
-      if (parse_symbol("(")) {
-        if (auto arguments = parse_argument_list()) {
-          if (parse_symbol(")") && parse_symbol("->") && parse_symbol("(")) {
-            if (auto return_type = parse_type()) {
-              if (parse_symbol(")")) {
-                if (auto function_body = parse_compound_statement()) {
-                  return make_unique<ast::FunctionDefinitionData>(
-                      std::move(function_name),
-                      std::move(arguments),
-                      std::move(return_type),
-                      std::move(function_body));
-                }
-              }
-            }
+      parse_symbol("(");
+      if (auto arguments = parse_argument_list()) {
+        parse_symbol(")");
+        parse_symbol("->");
+        parse_symbol("(");
+        if (auto return_type = parse_type()) {
+          parse_symbol(")");
+          if (auto function_body = parse_compound_statement()) {
+            return make_unique<ast::FunctionDefinitionData>(
+              std::move(function_name),
+              std::move(arguments),
+              std::move(return_type),
+              std::move(function_body));
           }
         }
       }
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
@@ -103,30 +109,25 @@ ast::ArgumentListPtr Parser::parse_argument_list() {
   std::vector<ast::ArgumentPtr> arguments;
   if (auto first_argument = parse_argument()) {
     arguments.push_back(std::move(first_argument));
-    while (true) {
-      const auto s = snapshot();
-      if (parse_symbol(",")) {
-        if (auto argument = parse_argument()) {
-          arguments.push_back(std::move(argument));
-          continue;
-        }
+    while (try_symbol(",")) {
+      if (auto argument = parse_argument()) {
+        arguments.push_back(std::move(argument));
+      } else {
+        fail();
       }
-      rewind(s);
-      break;
     }
   }
   return make_unique<ast::ArgumentListData>(std::move(arguments));
 }
 
 ast::ArgumentPtr Parser::parse_argument() {
-  const auto s = snapshot();
   if (auto argument_type = parse_type()) {
     if (auto argument_name = parse_identifier()) {
       return make_unique<ast::ArgumentData>(std::move(argument_type),
                                             std::move(argument_name));
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
@@ -155,164 +156,146 @@ ast::StatementPtr Parser::parse_statement() {
 
 ast::CompoundStatementPtr Parser::parse_compound_statement() {
   std::vector<ast::StatementPtr> statements;
-  const auto s = snapshot();
-  if (parse_symbol("{")) {
+  if (try_symbol("{")) {
     while (auto statement = parse_statement()) {
       statements.push_back(std::move(statement));
     }
-    if (parse_symbol("}")) {
-      return make_unique<ast::CompoundStatementData>(std::move(statements));
-    }
+    parse_symbol("}");
+    return make_unique<ast::CompoundStatementData>(std::move(statements));
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::IfStatementPtr Parser::parse_if_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("if") && parse_symbol("(")) {
+  if (try_symbol("if")) {
+    parse_symbol("(");
     if (auto condition = parse_expression()) {
-      if (parse_symbol(")")) {
-        if (auto compound_statement = parse_compound_statement()) {
-          return make_unique<ast::IfStatementData>(
-              std::move(condition),
-              std::move(compound_statement),
-              parse_else_statement());
-        }
+      parse_symbol(")");
+      if (auto compound_statement = parse_compound_statement()) {
+        return make_unique<ast::IfStatementData>(
+            std::move(condition),
+            std::move(compound_statement),
+            parse_else_statement());
       }
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::ElseStatementPtr Parser::parse_else_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("else")) {
+  if (try_symbol("else")) {
     if (auto else_if_statement = parse_if_statement()) {
       return std::move(else_if_statement);
     } else if (auto compound_statement = parse_compound_statement()) {
       return make_unique<ast::ElseStatementData>(std::move(compound_statement));
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::WhileStatementPtr Parser::parse_while_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("while") && parse_symbol("(")) {
+  if (try_symbol("while")) {
+    parse_symbol("(");
     if (auto condition = parse_expression()) {
-      if (parse_symbol(")")) {
-        if (auto compound_statement = parse_compound_statement()) {
-          return make_unique<ast::WhileStatementData>(
-              std::move(condition),
-              std::move(compound_statement));
-        }
+      parse_symbol(")");
+      if (auto compound_statement = parse_compound_statement()) {
+        return make_unique<ast::WhileStatementData>(
+            std::move(condition),
+            std::move(compound_statement));
       }
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::ForStatementPtr Parser::parse_for_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("for") && parse_symbol("(")) {
+  if (try_symbol("for")) {
+    parse_symbol("(");
     auto init_expression = parse_expression();
-    if (parse_symbol(";")) {
-      auto cond_expression = parse_expression();
-      if (parse_symbol(";")) {
-        auto reinit_expression = parse_expression();
-        if (parse_symbol(")")) {
-          if (auto compound_statement = parse_compound_statement()) {
-            return make_unique<ast::ForStatementData>(
-                std::move(init_expression),
-                std::move(cond_expression),
-                std::move(reinit_expression),
-                std::move(compound_statement));
-          }
-        }
-      }
+    parse_symbol(";");
+    auto cond_expression = parse_expression();
+    parse_symbol(";");
+    auto reinit_expression = parse_expression();
+    parse_symbol(")");
+    if (auto compound_statement = parse_compound_statement()) {
+      return make_unique<ast::ForStatementData>(
+          std::move(init_expression),
+          std::move(cond_expression),
+          std::move(reinit_expression),
+          std::move(compound_statement));
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::ReturnStatementPtr Parser::parse_return_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("return")) {
+  if (try_symbol("return")) {
     if (auto return_value = parse_expression()) {
-      if (parse_symbol(";")) {
-        return make_unique<ast::ReturnStatementData>(std::move(return_value));
-      }
+      parse_symbol(";");
+      return make_unique<ast::ReturnStatementData>(std::move(return_value));
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::BreakStatementPtr Parser::parse_break_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("break") && parse_symbol(";")) {
+  if (try_symbol("break")){
+    parse_symbol(";");
     return make_unique<ast::BreakStatementData>();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::ContinueStatementPtr Parser::parse_continue_statement() {
-  const auto s = snapshot();
-  if (parse_symbol("continue") && parse_symbol(";")) {
+  if (try_symbol("continue")) {
+    parse_symbol(";");
     return make_unique<ast::ContinueStatementData>();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::VariableDefinitionStatementPtr
 Parser::parse_variable_definition_statement() {
-  const auto s = snapshot();
   if (auto variable_definition = parse_variable_definition()) {
-    if (parse_symbol(";")) {
-      return make_unique<ast::VariableDefinitionStatementData>(
-          std::move(variable_definition));
-    }
+    parse_symbol(";");
+    return make_unique<ast::VariableDefinitionStatementData>(
+        std::move(variable_definition));
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::VariableDefinitionPtr Parser::parse_variable_definition() {
-  const auto s = snapshot();
-  if (parse_symbol("def")) {
+  if (try_symbol("def")) {
     if (auto type_name = parse_type()) {
-      const bool is_mutable = parse_symbol("var");
+      const bool is_mutable = try_symbol("var");
       if (auto variable_name = parse_identifier()) {
-        if (parse_symbol(":=")) {
-          if (auto expression = parse_expression()) {
-            return make_unique<ast::VariableDefinitionData>(
-                std::move(type_name),
-                is_mutable,
-                std::move(variable_name),
-                std::move(expression));
-          }
+        parse_symbol(":=");
+        if (auto expression = parse_expression()) {
+          return make_unique<ast::VariableDefinitionData>(
+              std::move(type_name),
+              is_mutable,
+              std::move(variable_name),
+              std::move(expression));
         }
       }
     }
+    fail();
   }
-  rewind(s);
   return nullptr;
 }
 
 ast::ExpressionStatementPtr Parser::parse_expression_statement() {
-  const auto s = snapshot();
-  auto expression = parse_expression();
-  if (parse_symbol(";")) {
+  if (auto expression = parse_expression()) {
+    parse_symbol(";");
     return make_unique<ast::ExpressionStatementData>(std::move(expression));
+  } else if (try_symbol(";")) {
+    return make_unique<ast::ExpressionStatementData>(nullptr);
   }
-  rewind(s);
   return nullptr;
 }
 
@@ -322,43 +305,42 @@ ast::ExpressionPtr Parser::parse_expression() {
 
 ast::AssignExpressionPtr Parser::parse_assign_expression() {
   if (auto lhs_expression = parse_or_expression()) {
-    const auto s = snapshot();
-    if (parse_symbol(":=")) {
+    if (try_symbol(":=")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::AssignExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if(parse_symbol(":+=")) {
+      fail();
+    } else if (try_symbol(":+=")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::AddAssignExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if(parse_symbol(":-=")) {
+      fail();
+    } else if (try_symbol(":-=")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::SubtractAssignExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if(parse_symbol(":*=")) {
+      fail();
+    } else if (try_symbol(":*=")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::MultiplyAssignExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if(parse_symbol(":/=")) {
+      fail();
+    } else if (try_symbol(":/=")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::DivideAssignExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if(parse_symbol(":%=")) {
+      fail();
+    } else if (try_symbol(":%=")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::ModuloAssignExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
+      fail();
     }
     return std::move(lhs_expression);
   }
@@ -367,14 +349,13 @@ ast::AssignExpressionPtr Parser::parse_assign_expression() {
 
 ast::OrExpressionPtr Parser::parse_or_expression() {
   if (auto lhs_expression = parse_and_expression()) {
-    const auto s = snapshot();
-    if (parse_symbol("or")) {
+    if (try_symbol("or")) {
       if (auto rhs_expression = parse_or_expression()) {
         return make_unique<ast::OrExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
+      fail();
     }
-    rewind(s);
     return std::move(lhs_expression);
   }
   return nullptr;
@@ -382,14 +363,13 @@ ast::OrExpressionPtr Parser::parse_or_expression() {
 
 ast::AndExpressionPtr Parser::parse_and_expression() {
   if (auto lhs_expression = parse_comparative_expression()) {
-    const auto s = snapshot();
-    if (parse_symbol("and")) {
+    if (try_symbol("and")) {
       if (auto rhs_expression = parse_and_expression()) {
         return make_unique<ast::AndExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
+      fail();
     }
-    rewind(s);
     return std::move(lhs_expression);
   }
   return nullptr;
@@ -397,43 +377,42 @@ ast::AndExpressionPtr Parser::parse_and_expression() {
 
 ast::ComparativeExpressionPtr Parser::parse_comparative_expression() {
   if (auto lhs_expression = parse_additive_expression()) {
-    const auto s = snapshot();
-    if (parse_symbol("=")) {
+    if (try_symbol("=")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::EqualExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol("=/")) {
+      fail();
+    } else if (try_symbol("=/")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::NotEqualExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol("<")) {
+      fail();
+    } else if (try_symbol("<")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::LessExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol(">")) {
+      fail();
+    } else if (try_symbol(">")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::GreaterExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol("<=")) {
+      fail();
+    } else if (try_symbol("<=")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::LessOrEqualExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol(">=")) {
+      fail();
+    } else if (try_symbol(">=")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::GreaterOrEqualExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
+      fail();
     }
     return std::move(lhs_expression);
   }
@@ -442,19 +421,18 @@ ast::ComparativeExpressionPtr Parser::parse_comparative_expression() {
 
 ast::AdditiveExpressionPtr Parser::parse_additive_expression() {
   if (auto lhs_expression = parse_multiplicative_expression()) {
-    const auto s = snapshot();
-    if (parse_symbol("+")) {
+    if (try_symbol("+")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::AddExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol("-")) {
+      fail();
+    } else if (try_symbol("-")) {
       if (auto rhs_expression = parse_additive_expression()) {
         return make_unique<ast::SubtractExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
+      fail();
     }
     return std::move(lhs_expression);
   }
@@ -463,25 +441,24 @@ ast::AdditiveExpressionPtr Parser::parse_additive_expression() {
 
 ast::MultiplicativeExpressionPtr Parser::parse_multiplicative_expression() {
   if (auto lhs_expression = parse_unary_expression()) {
-    const auto s = snapshot();
-    if (parse_symbol("*")) {
+    if (try_symbol("*")) {
       if (auto rhs_expression = parse_multiplicative_expression()) {
         return make_unique<ast::MultiplyExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol("/")) {
+      fail();
+    } else if (try_symbol("/")) {
       if (auto rhs_expression = parse_multiplicative_expression()) {
         return make_unique<ast::DivideExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
-    } else if (parse_symbol("%")) {
+      fail();
+    } else if (try_symbol("%")) {
       if (auto rhs_expression = parse_multiplicative_expression()) {
         return make_unique<ast::ModuloExpressionData>(
             std::move(lhs_expression), std::move(rhs_expression));
       }
-      rewind(s);
+      fail();
     }
     return std::move(lhs_expression);
   }
@@ -489,17 +466,16 @@ ast::MultiplicativeExpressionPtr Parser::parse_multiplicative_expression() {
 }
 
 ast::UnaryExpressionPtr Parser::parse_unary_expression() {
-  const auto s = snapshot();
-  if (parse_symbol("not")) {
+  if (try_symbol("not")) {
     if (auto unary_expression = parse_unary_expression()) {
       return make_unique<ast::NotExpressionData>(std::move(unary_expression));
     }
-    rewind(s);
-  } else if (parse_symbol("~")) {
+    fail();
+  } else if (try_symbol("~")) {
     if (auto unary_expression = parse_unary_expression()) {
       return make_unique<ast::MinusExpressionData>(std::move(unary_expression));
     }
-    rewind(s);
+    fail();
   } else if (auto postfix_expression = parse_postfix_expression()) {
     return std::move(postfix_expression);
   }
@@ -516,18 +492,18 @@ ast::PostfixExpressionPtr Parser::parse_postfix_expression() {
 }
 
 ast::FunctionCallExpressionPtr Parser::parse_function_call_expression() {
-  const auto s = snapshot();
   if (auto function_name = parse_identifier()) {
-    if (parse_symbol("(")) {
+    if (try_symbol("(")) {
       if (auto parameter_list = parse_parameter_list()) {
-        if (parse_symbol(")")) {
-          return make_unique<ast::FunctionCallExpressionData>(
-              std::move(function_name), std::move(parameter_list));
-        }
+        parse_symbol(")");
+        return make_unique<ast::FunctionCallExpressionData>(
+            std::move(function_name), std::move(parameter_list));
       }
+      fail();
+    } else {
+      advance(-1);
     }
   }
-  rewind(s);
   return nullptr;
 }
 
@@ -535,16 +511,12 @@ ast::ParameterListPtr Parser::parse_parameter_list() {
   std::vector<ast::ParameterPtr> parameters;
   if (auto first_parameter = parse_parameter()) {
     parameters.push_back(std::move(first_parameter));
-    while (true) {
-      const auto s = snapshot();
-      if (parse_symbol(",")) {
-        if (auto parameter = parse_parameter()) {
-          parameters.push_back(std::move(parameter));
-          continue;
-        }
+    while (try_symbol(",")) {
+      if (auto parameter = parse_parameter()) {
+        parameters.push_back(std::move(parameter));
+      } else {
+        fail();
       }
-      rewind(s);
-      break;
     }
   }
   return make_unique<ast::ParameterListData>(std::move(parameters));
@@ -558,15 +530,13 @@ ast::ParameterPtr Parser::parse_parameter() {
 }
 
 ast::PrimaryExpressionPtr Parser::parse_primary_expression() {
-  const auto s = snapshot();
-  if (parse_symbol("(")) {
+  if (try_symbol("(")) {
     if (auto expression = parse_expression()) {
-      if (parse_symbol(")")) {
-        return make_unique<ast::ParenthesizedExpressionData>(
+      parse_symbol(")");
+      return make_unique<ast::ParenthesizedExpressionData>(
             std::move(expression));
-      }
     }
-    rewind(s);
+    fail();
   } else if (auto identifier = parse_identifier()) {
     return make_unique<ast::IdentifierExpressionData>(
         std::move(identifier));
@@ -627,6 +597,13 @@ auto Parser::snapshot() const -> Pointer {
 
 void Parser::rewind(Pointer p) {
   current_ = p;
+}
+
+
+void Parser::fail() {
+  std::stringstream ss;
+  ss << "unexpected token " << current_string() << " near at " << current_->line();
+  throw std::runtime_error(ss.str());
 }
 
 }  // namespace klang

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -9,7 +9,8 @@ namespace klang {
 class Parser {
  public:
   Parser(TokenVector tokens);
-  bool parse_symbol(const char* str);
+  void parse_symbol(const char* str);
+  bool try_symbol(const char* str);
   ast::IdentifierPtr parse_identifier();
   ast::TypePtr parse_type();
   ast::IntegerLiteralPtr parse_integer_literal();
@@ -52,6 +53,7 @@ class Parser {
   bool advance(int count);
   Pointer snapshot() const;
   void rewind(Pointer p);
+  void fail();
   const TokenVector tokens_;
   Pointer current_;
 };


### PR DESCRIPTION
Eitherの実装が手こずりそうなので、例外を使ってエラーを表現してみました。
`parse_type()`と`parse_function_call_expression()`を少し意図から変えました。
