### PR TITLE
configure.ac の整理

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,23 +2,34 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT(Klang, 0.0.1, klang-project@kmc.gr.jp, KMC, https://github.com/kmc-jp/Klang)
+AC_INIT(Klang, 0.0.1, klang-project@kmc.gr.jp, Klang, https://github.com/kmc-jp/Klang)
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CXX
+AC_PROG_CC
 
 # Checks for libraries.
 AC_PROG_RANLIB
 
 # Checks for header files.
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h float.h limits.h netdb.h stddef.h stdlib.h string.h strings.h sys/time.h sys/timeb.h unistd.h wchar.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL
+AC_C_INLINE
+AC_TYPE_PID_T
+AC_TYPE_SIZE_T
+AC_CHECK_TYPES([ptrdiff_t])
 
 # Checks for library functions.
+AC_FUNC_FORK
+AC_FUNC_MALLOC
+AC_FUNC_MMAP
+AC_FUNC_STRERROR_R
+AC_CHECK_FUNCS([dup2 fchdir getcwd getpagesize gettimeofday memset mkdir munmap regcomp rmdir socket strcasecmp strchr strdup strerror strrchr strstr strtol strtoull])
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile


### PR DESCRIPTION
autoscan をかけたら、gtest の関係でいろいろなフラグが付いた。

パッケージ名がKMC になっていたのが、klang であるべきだという点に気づいたので修正。
