### PR TITLE
tokenVec にoperator==() が実装されているので、そのまま比較できる

### DIFF
--- a/test/test_lexer.cpp
+++ b/test/test_lexer.cpp
@@ -12,6 +12,38 @@ TEST(lexer, emptySource) {
   EXPECT_EQ("", test::to_string(tokens));
 }
 
+TEST(lexer, return0) {
+  std::stringstream is;
+  is <<
+R"(def main() -> (int) {
+  return 0;
+})";
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
+  using T = klang::Token;
+  using klang::TokenType;
+  klang::TokenVector const expect = {
+      T{TokenType::SYMBOL, "def", 1},
+      T{TokenType::IDENTIFIER, "main", 1},
+      T{TokenType::SYMBOL, "(", 1},
+      T{TokenType::SYMBOL, ")", 1},
+      T{TokenType::SYMBOL, "->", 1},
+      T{TokenType::SYMBOL, "(", 1},
+      T{TokenType::SYMBOL, "int", 1},
+      T{TokenType::SYMBOL, ")", 1},
+      T{TokenType::SYMBOL, "{", 1},
+      T{TokenType::SYMBOL, "return", 2},
+      T{TokenType::NUMBER, "0", 2},
+      T{TokenType::SYMBOL, ";", 2},
+      T{TokenType::SYMBOL, "}", 3},
+  };
+  ASSERT_EQ(expect.size(), tokens.size());
+  for(size_t i(0); i < expect.size(); ++i)
+    EXPECT_EQ(expect[i], tokens[i]);
+}
+
 TEST(lexer, hello) {
   std::stringstream is;
   is <<

--- a/test/test_lexer.cpp
+++ b/test/test_lexer.cpp
@@ -9,7 +9,7 @@ TEST(lexer, emptySource) {
   bool success;
   std::tie(success, tokens) = klang::tokenize(is);
   EXPECT_TRUE(success);
-  EXPECT_EQ("", test::to_string(tokens));
+  EXPECT_EQ(klang::TokenVector(), tokens);
 }
 
 TEST(lexer, return0) {
@@ -39,9 +39,7 @@ R"(def main() -> (int) {
       T{TokenType::SYMBOL, ";", 2},
       T{TokenType::SYMBOL, "}", 3},
   };
-  ASSERT_EQ(expect.size(), tokens.size());
-  for(size_t i(0); i < expect.size(); ++i)
-    EXPECT_EQ(expect[i], tokens[i]);
+  ASSERT_EQ(expect, tokens);
 }
 
 TEST(lexer, hello) {
@@ -84,9 +82,7 @@ def main() -> (int) {
       T{TokenType::SYMBOL, ";", 9},
       T{TokenType::SYMBOL, "}", 10},
   };
-  ASSERT_EQ(expect.size(), tokens.size());
-  for(size_t i(0); i < expect.size(); ++i)
-    EXPECT_EQ(expect[i], tokens[i]);
+  ASSERT_EQ(expect, tokens);
 }
 
 TEST(lexer, NestedComment1) {
@@ -107,9 +103,7 @@ def placeholder
       T{TokenType::SYMBOL, "def", 4},
       T{TokenType::IDENTIFIER, "placeholder", 4},
   };
-  ASSERT_EQ(expect.size(), tokens.size());
-  for(size_t i(0); i < expect.size(); ++i)
-    EXPECT_EQ(expect[i], tokens[i]);
+  ASSERT_EQ(expect, tokens);
 }
 
 TEST(lexer, brokenComment1Fixed) {

--- a/test/test_lexer_fail.cpp
+++ b/test/test_lexer_fail.cpp
@@ -22,9 +22,7 @@ def placeholder
       T{TokenType::SYMBOL, "def", 5},
       T{TokenType::IDENTIFIER, "placeholder", 5},
   };
-  ASSERT_EQ(expect.size(), tokens.size());
-  for(size_t i(0); i < expect.size(); ++i)
-    EXPECT_EQ(expect[i], tokens[i]);
+  ASSERT_EQ(expect, tokens);
 }
 
 TEST(lexer, split12345abcde) {


### PR DESCRIPTION
こっちのほうが失敗時に詳細に出て良い。
#76 に依存している。
