### PR TITLE
fix either test for union-either

### DIFF
--- a/test/test_either.cpp
+++ b/test/test_either.cpp
@@ -12,38 +12,38 @@ TEST(either, left) {
   ASSERT_TRUE(e.is_left());
   ASSERT_FALSE(e.is_right());
   ASSERT_FALSE(static_cast<bool>(e));
-  ASSERT_EQ(value, e.left_value());
+  ASSERT_EQ(value, e.left().value());
 
-  ASSERT_DEATH(e.right_value(), "");
+  ASSERT_DEATH(e.right().value(), "");
   ASSERT_DEATH(*e, "");
 }
 
 TEST(either, right) {
   const std::string value("right");
-  const Either<double, std::string> e(value);
+  const Either<double, std::string> e(right_tag, value);
   ASSERT_FALSE(e.is_left());
   ASSERT_TRUE(e.is_right());
   ASSERT_TRUE(static_cast<bool>(e));
-  ASSERT_EQ(value, e.right_value());
+  ASSERT_EQ(value, e.right().value());
 
   // We can treat the Either<S,T> value as the pointer of type T,
   // when the value has the right value.
   ASSERT_EQ(value, *e);
   ASSERT_EQ(value.length(), e->length());
 
-  ASSERT_DEATH(e.left_value(), "");
+  ASSERT_DEATH(e.left(), "");
 }
 
 TEST(either, same_type) {
   const std::string value("both");
   Either<std::string, std::string> l(left_tag, value);
-  const Either<std::string, std::string> r(value);
+  const Either<std::string, std::string> r(right_tag, value);
 
   ASSERT_TRUE(l.is_left());
   ASSERT_FALSE(r.is_left());
   ASSERT_FALSE(l.is_right());
   ASSERT_TRUE(r.is_right());
-  ASSERT_EQ(l.left_value(), *r);
+  ASSERT_EQ(l.left().value(), *r);
 
   l = r;
   ASSERT_TRUE(l.is_right());
@@ -53,24 +53,24 @@ TEST(either, same_type) {
 TEST(either, swap) {
   const std::string value("value");
   Either<std::string, int> e1(left_tag, value);
-  Either<std::string, int> e2(42);
-  ASSERT_EQ(value, e1.left_value());
+  Either<std::string, int> e2(right_tag, 42);
+  ASSERT_EQ(value, e1.left().value());
   ASSERT_EQ(42, *e2);
 
   swap(e1, e2);
   ASSERT_EQ(42, *e1);
-  ASSERT_EQ(value, e2.left_value());
+  ASSERT_EQ(value, e2.left().value());
 
   swap(e1, e2);
-  ASSERT_EQ(value, e1.left_value());
+  ASSERT_EQ(value, e1.left().value());
   ASSERT_EQ(42, *e2);
 }
 
 TEST(either, comparators) {
   const Either<int, int> e1(left_tag, 0);
-  const Either<int, int> e2(1);
+  const Either<int, int> e2(right_tag, 1);
   const Either<int, int> e3(left_tag, 2);
-  const Either<int, int> e4(3);
+  const Either<int, int> e4(right_tag, 3);
 
   ASSERT_TRUE(e1 < e2);
   ASSERT_FALSE(e2 < e1);
@@ -85,9 +85,9 @@ TEST(either, comparators) {
 }
 
 TEST(either, equals) {
-  const Either<int, int> e1(0);
+  const Either<int, int> e1(right_tag, 0);
   const Either<int, int> e2(left_tag, 0);
-  const Either<int, int> e3(0);
+  const Either<int, int> e3(right_tag, 0);
   const Either<int, int> e4(left_tag, 0);
 
   ASSERT_FALSE(e1 == e2);


### PR DESCRIPTION
<del>https://travis-ci.org/kmc-jp/Klang/builds/38156618 Clang でビルド転けたけど、`Either` のほうのバグな気がする？</del> fixed by 6c9499dc13d7c00d514dff99673755d1840b2641

`e.right().value()` 相当の`e.right_value()` が欲しいように思うのと、やはり`Either` のctor に`T`型の値`t` だけを渡すことによって、`Right`値が作れた方が(便利|自然) に思う。
