### PR TITLE
tokenize のシグネチャを変更

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -144,24 +144,24 @@ TokenType match_type(const_iterator head, const_iterator tail) {
   return TokenType::UNKNOWN;
 }
 
-std::string extract_string(const std::string& str) {
-  if (str.front() == '"') {
+std::string extract_string(const_iterator head, const_iterator tail) {
+  if (*head == '"') {
     bool escaped = false;
     std::string new_str;
-    for(auto c : str) {
+    for(auto it(head); it != tail; ++it) {
       if (escaped) {
-        if(c == '"') new_str.push_back('"');
-        if(c == 'n') new_str.push_back('\n');
+        if(*it == '"') new_str.push_back('"');
+        if(*it == 'n') new_str.push_back('\n');
         escaped = false;
-      } else if (c == '\\') {
+      } else if (*it == '\\') {
         escaped = true;
-      } else if (c != '"') {
-        new_str.push_back(c);
+      } else if (*it != '"') {
+        new_str.push_back(*it);
       }
     }
     return new_str;
   }
-  return str;
+  return std::string{head, tail};
 }
 
 TokenVector tokenize(std::istream& is) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -83,11 +83,13 @@ bool ignore(const std::string& str) {
   return std::isspace(str[0]);
 }
 
-bool singleline_comment(const std::string& str) {
+bool singleline_comment(const_iterator head, const_iterator tail) {
   using std::begin;
   using std::end;
-  bool inside = (str.back() == '\n' || str.find("\n") == std::string::npos);
-  return std::equal(begin(str), std::next(begin(str), 2), "~~") && inside;
+  if(std::equal(head, std::next(head, 2), "~~")) {
+      return std::find(head, tail, '\n') == std::prev(tail);
+  }
+  return false;
 }
 
 bool multiline_comment(const std::string& str) {
@@ -109,8 +111,8 @@ bool multiline_comment(const std::string& str) {
   return false;
 }
 
-bool comment(const std::string& str) {
-  return (singleline_comment(str) || multiline_comment(str));
+bool comment(const_iterator head, const_iterator tail) {
+  return (singleline_comment(head, tail) || multiline_comment(head, tail));
 }
 
 bool string_token(const std::string& str) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -3,7 +3,6 @@
 #include <cctype>
 #include <algorithm>
 #include <iterator>
-#include <vector>
 
 namespace klang {
 namespace {
@@ -164,7 +163,7 @@ std::string extract_string(const_iterator head, const_iterator tail) {
   return std::string{head, tail};
 }
 
-TokenVector tokenize(std::istream& is) {
+std::tuple<bool, TokenVector> tokenize(std::istream& is) {
   using std::begin;
   using std::end;
   std::string const code(std::string{std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>()} + '\n');
@@ -186,7 +185,8 @@ TokenVector tokenize(std::istream& is) {
     }
     if (*it == '\n') ++line;
   }
-  return tokens;
+  ++head; // head とend(code) が一致した時が、最後まで食べた時である。
+  return std::make_tuple(head == end(code), tokens);
 }
 
 bool operator==(Token const& lhs, Token const& rhs) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -39,12 +39,12 @@ bool decimal_digit(char c) {
   return std::isdigit(c);
 }
 
-bool identifier(const std::string& str) {
-  if (str.empty() || !alphabet_or_bar(str.front())) {
+bool identifier(const_iterator head, const_iterator tail) {
+  if (head == tail || !alphabet_or_bar(*head)) {
     return false;
   }
-  for (char c : str) {
-    if (!alphabet_or_bar(c) && !decimal_digit(c)) {
+  for (auto it(head); it != tail; ++it) {
+    if (!alphabet_or_bar(*it) && !decimal_digit(*it)) {
       return false;
     }
   }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -51,15 +51,13 @@ bool identifier(const_iterator head, const_iterator tail) {
   return true;
 }
 
-bool decimal_integer(const std::string& str) {
-  if (str == "0") return true;
-  if (str.empty() || !nonzero_digit(str.front())) {
+bool decimal_integer(const_iterator head, const_iterator tail) {
+  if (*head == '0' && std::distance(head, tail) == 1) return true;
+  if (head == tail || !nonzero_digit(*head)) {
     return false;
   }
-  for (char c : str) {
-    if (!decimal_digit(c)) {
-      return false;
-    }
+  for (auto it(head); it != tail; ++it) {
+    if (!decimal_digit(*it)) return false;
   }
   return true;
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -77,9 +77,11 @@ bool symbol(const_iterator head, const_iterator tail) {
   return (std::find(begin(symbol_list), end(symbol_list), str) != end(symbol_list));
 }
 
-bool ignore(const std::string& str) {
-  if(str.size() != 1) return false;
-  return std::isspace(str[0]);
+bool ignore(const_iterator head, const_iterator tail) {
+  if(std::distance(head, tail) != 1) return false;
+  // `std::distance(head, tail) != 1` は、`next(head) != tail` のほうが高速かもしれない。
+  // 意図が失われるので、ひとまず`distance` を使う。
+  return std::isspace(*head);
 }
 
 bool singleline_comment(const_iterator head, const_iterator tail) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -133,13 +133,13 @@ bool string_token(const std::string& str) {
   return false;
 }
 
-TokenType match_type(std::string const& str) {
-  if (comment(str)) return TokenType::IGNORE;
-  if (symbol(str)) return TokenType::SYMBOL;
-  if (identifier(str)) return TokenType::IDENTIFIER;
-  if (decimal_integer(str)) return TokenType::NUMBER;
-  if (string_token(str)) return TokenType::STRING;
-  if (ignore(str)) return TokenType::IGNORE;
+TokenType match_type(const_iterator head, const_iterator tail) {
+  if (comment(head, tail)) return TokenType::IGNORE;
+  if (symbol(head, tail)) return TokenType::SYMBOL;
+  if (identifier(head, tail)) return TokenType::IDENTIFIER;
+  if (decimal_integer(head, tail)) return TokenType::NUMBER;
+  if (string_token(head, tail)) return TokenType::STRING;
+  if (ignore(head, tail)) return TokenType::IGNORE;
   return TokenType::UNKNOWN;
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -114,16 +114,16 @@ bool comment(const_iterator head, const_iterator tail) {
   return (singleline_comment(head, tail) || multiline_comment(head, tail));
 }
 
-bool string_token(const std::string& str) {
+bool string_token(const_iterator head, const_iterator tail) {
   using std::begin;
   using std::end;
-  if (str.front() == '"') {
+  if (*head == '"') {
     bool escaped = false;
-    for(auto it = std::next(begin(str)); it != end(str); ++it) {
+    for(auto it = std::next(head); it != tail; ++it) {
       if (*it == '\\') {
         escaped = true;
       } else if (*it == '"' && (!escaped)) {
-        return std::next(it) == end(str);
+        return std::next(it) == tail;
       } else {
         escaped = false;
       }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -64,9 +64,10 @@ bool decimal_integer(const std::string& str) {
   return true;
 }
 
-bool symbol(const std::string& str) {
+bool symbol(const_iterator head, const_iterator tail) {
   using std::begin;
   using std::end;
+  std::string const str(head, tail);
   static std::vector<std::string> const symbol_list = {
     "~", "+", "-", "*", "/", "%",
     ":=", ":+=", ":-=", ":*=", ":/=", ":%=",

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -92,12 +92,12 @@ bool singleline_comment(const_iterator head, const_iterator tail) {
   return false;
 }
 
-bool multiline_comment(const std::string& str) {
+bool multiline_comment(const_iterator head, const_iterator tail) {
   using std::begin;
   using std::end;
-  if (std::equal(begin(str), std::next(begin(str), 2), "{~")) {
+  if (std::equal(head, std::next(head, 2), "{~")) {
     int nest = 0;
-    for(auto it = begin(str); std::next(it) != end(str); ++it) {
+    for(auto it = head; std::next(it) != tail; ++it) {
       std::string tk(it, std::next(it, 2));
       if (tk == "{~") {
         ++nest;
@@ -105,7 +105,7 @@ bool multiline_comment(const std::string& str) {
         --nest;
       }
     }
-    bool closed = (nest == 0 && std::equal(std::prev(end(str), 2), std::prev(end(str)), "~}"));
+    bool closed = nest == 0 && std::equal(std::prev(tail, 2), std::prev(tail), "~}");
     return (nest > 0 || closed);
   }
   return false;

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -3,6 +3,7 @@
 
 #include <istream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace klang {
@@ -35,7 +36,7 @@ bool operator!=(Token const& lhs, Token const& rhs);
 
 typedef std::vector<Token> TokenVector;
 
-TokenVector tokenize(std::istream& is);
+std::tuple<bool, TokenVector> tokenize(std::istream& is);
 
 }  // namespace klang
 

--- a/test/test_lexer.cpp
+++ b/test/test_lexer.cpp
@@ -5,7 +5,10 @@
 
 TEST(lexer, emptySource) {
   std::stringstream is;
-  auto tokens = klang::tokenize(is);
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
   EXPECT_EQ("", test::to_string(tokens));
 }
 
@@ -23,7 +26,10 @@ def main() -> (int) {
   return 0;
 }
 )";
-  auto tokens = klang::tokenize(is);
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
   using T = klang::Token;
   using klang::TokenType;
   klang::TokenVector const expect = {
@@ -59,7 +65,10 @@ R"({~ comment
 ~}
 def placeholder
 )";
-  auto tokens = klang::tokenize(is);
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
   using T = klang::Token;
   using klang::TokenType;
   klang::TokenVector const expect = {

--- a/test/test_lexer_fail.cpp
+++ b/test/test_lexer_fail.cpp
@@ -12,7 +12,10 @@ R"(
 ~}
 def placeholder
 )";
-  auto tokens = klang::tokenize(is);
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
   using T = klang::Token;
   using klang::TokenType;
   klang::TokenVector const expect = {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -4,7 +4,10 @@
 
 TEST(parser, emptySource) {
   std::stringstream is;
-  auto tokens = klang::tokenize(is);
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
   klang::Parser p(tokens);
   auto ptu = p.parse_translation_unit();
   ASSERT_TRUE(ptu != nullptr);
@@ -17,7 +20,10 @@ R"(def main() -> (int) {
   x := (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( x ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
   return x;
 })";
-  auto tokens = klang::tokenize(is);
+  klang::TokenVector tokens;
+  bool success;
+  std::tie(success, tokens) = klang::tokenize(is);
+  EXPECT_TRUE(success);
   klang::Parser p(tokens);
   EXPECT_TRUE(p.parse_translation_unit() != nullptr);
 }


### PR DESCRIPTION
`std::tuple<bool, TokenVector>` を返すようになり、tokenize に失敗したことを検知できるようにした。
#78 に依存
