### PR TITLE
ソースコードをコンパイルして、正常終了するかどうか確認するテスト

### DIFF
--- a/test/KlangSrc/return0.klang
+++ b/test/KlangSrc/return0.klang
@@ -1,0 +1,3 @@
+def main() -> (int) {
+  return 0;
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,3 +1,5 @@
+KLANG = ../src/klang
+
 GTEST_DIR = gtest
 GTEST_FLAGS = -I $(GTEST_DIR) -pthread -isystem
 AM_CXXFLAGS = -O2 -std=c++11 -Wall -Wextra -I../src $(GTEST_FLAGS)
@@ -9,8 +11,11 @@ libgtest_all_a_CXXFLAGS = -O2 -std=c++11 -I../src $(GTEST_FLAGS)
 
 GTEST_FILES = helper_test_main.cpp $(GTEST_DIR)/gtest.h
 
-TESTS = test_nothing test_sample1 test_lexer test_lexer_fail test_parser test_either
-XFAIL_TESTS = test_lexer_fail
+COMPILE_SRC_DIR = KlangSrc
+
+COMPILE_TESTS = return0.out
+TESTS = test_nothing test_sample1 test_lexer test_lexer_fail test_parser test_either $(COMPILE_TESTS)
+XFAIL_TESTS = test_lexer_fail $(COMPILE_TESTS) # main が完成するまでは全てのコンパイルテストは失敗時する。
 
 check_PROGRAMS = $(TESTS)
 test_nothing_SOURCES = test_nothing.cpp # not using gtest
@@ -28,3 +33,6 @@ test_parser_LDADD = $(check_LIBRARIES) ../src/libparser.a ../src/liblexer.a
 
 test_either_SOURCES = test_either.cpp $(GTEST_FILES)
 test_either_LDADD = $(check_LIBRARIES)
+
+return0.out: $(COMPILE_SRC_DIR)/return0.klang
+	$(KLANG) $< -o $@


### PR DESCRIPTION
```
return0.out: $(COMPILE_SRC_DIR)/return0.klang
    $(KLANG) $< -o $@
```

を、
`return0_SOURCES = $(COMPILE_SRC_DIR)/return0.klang`
的に書ける方法って無いのかなぁ……
