### PR TITLE
Makefile.amの拡張性を改善(ref #88)

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -13,7 +13,7 @@ GTEST_FILES = helper_test_main.cpp $(GTEST_DIR)/gtest.h
 
 COMPILE_SRC_DIR = KlangSrc
 
-COMPILE_TESTS = return0.out
+COMPILE_TESTS = return0
 TESTS = test_nothing test_sample1 test_lexer test_lexer_fail test_parser test_either $(COMPILE_TESTS)
 XFAIL_TESTS = test_lexer_fail $(COMPILE_TESTS) # main が完成するまでは全てのコンパイルテストは失敗時する。
 
@@ -34,5 +34,7 @@ test_parser_LDADD = $(check_LIBRARIES) ../src/libparser.a ../src/liblexer.a
 test_either_SOURCES = test_either.cpp $(GTEST_FILES)
 test_either_LDADD = $(check_LIBRARIES)
 
-return0.out: $(COMPILE_SRC_DIR)/return0.klang
-	$(KLANG) $< -o $@
+return0_SOURCES = $(COMPILE_SRC_DIR)/return0.klang
+
+.klang.o:
+	$(KLANG) $< -c -o $@


### PR DESCRIPTION
https://github.com/kmc-jp/Klang/pull/88

> ```
> return0.out: $(COMPILE_SRC_DIR)/return0.klang
>     $(KLANG) $< -o $@
> ```
> 
> を、
> `return0_SOURCES = $(COMPILE_SRC_DIR)/return0.klang`
> 的に書ける方法って無いのかなぁ……

これでどうでしょうか。
